### PR TITLE
Add SIGTERM handling

### DIFF
--- a/src/srnd/daemon.go
+++ b/src/srnd/daemon.go
@@ -56,7 +56,12 @@ type NNTPDaemon struct {
 }
 
 func (self NNTPDaemon) End() {
-	self.listener.Close()
+	if self.listener != nil {
+		self.listener.Close()
+	}
+	if self.database != nil {
+		self.database.Close()
+	}
 }
 
 func (self *NNTPDaemon) GetDatabase() Database {

--- a/srnd.go
+++ b/srnd.go
@@ -5,6 +5,8 @@ import (
 	"github.com/majestrate/srndv2/src/srnd"
 	"log"
 	"os"
+	"os/signal"
+	"syscall"
 	//   _ "net/http/pprof"
 	//  "net/http"
 )
@@ -25,6 +27,15 @@ func main() {
 		} else if action == "run" {
 			log.Printf("Starting up %s...", srnd.Version())
 			daemon.Setup()
+			c := make(chan os.Signal, 1)
+			signal.Notify(c, os.Interrupt)
+			signal.Notify(c, syscall.SIGTERM)
+			go func() {
+				<-c
+				log.Println("Shutting down...")
+				daemon.End()
+				os.Exit(0)
+			}()
 			daemon.Run()
 		} else if action == "tool" {
 			if len(os.Args) > 2 {


### PR DESCRIPTION
Regarding #14, this is a necessary because Go programs can't fork. I already tested this with systemd and it works fine.
You might want to add more things to the clean-up function in daemon.go