### PR TITLE
Add IP range bans for redis driver

### DIFF
--- a/src/srnd/util.go
+++ b/src/srnd/util.go
@@ -460,3 +460,42 @@ func nntpLoginCredHash(passwd, salt string) (str string) {
 	str = base64.StdEncoding.EncodeToString(h[:])
 	return
 }
+
+func IsSubnet(cidr string) (bool, *net.IPNet) {
+	_, ipnet, err := net.ParseCIDR(cidr)
+	if err == nil {
+		return true, ipnet
+	}
+	return false, nil
+}
+
+func IPNet2MinMax(inet *net.IPNet) (min, max net.IP) {
+	netb := []byte(inet.IP)
+	maskb := []byte(inet.Mask)
+	maxb := make([]byte, len(netb))
+
+	for i, _ := range maxb {
+		maxb[i] = netb[i] | (^maskb[i])
+	}
+	min = net.IP(netb)
+	max = net.IP(maxb)
+	return
+}
+
+func ZeroIPString(ip net.IP) string {
+	p := ip
+
+	if len(ip) == 0 {
+		return "<nil>"
+	}
+
+	if p4 := p.To4(); len(p4) == net.IPv4len {
+		return fmt.Sprintf("%03d.%03d.%03d.%03d", p4[0], p4[1], p4[2], p4[3])
+	}
+	if len(p) == net.IPv6len {
+		//>IPv6
+		//ishygddt
+		return fmt.Sprintf("%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x", p[0], p[1], p[2], p[3], p[4], p[5], p[6], p[7], p[8], p[9], p[10], p[11], p[12], p[13], p[14], p[15])
+	}
+	return "?"
+}


### PR DESCRIPTION
Regarding  #7, 
This would have been quite easy if it weren't for the fact that IPv6 addresses have 128 bits and therefore can't be represented by a 64 bit float.
Because of this I had to fuck around with string ordering, but at least it's done.

This should still be tested though.