### PR TITLE
Make redis optional at compile time

### DIFF
--- a/src/srnd/redis.go
+++ b/src/srnd/redis.go
@@ -1,3 +1,5 @@
+// +build !disable_redis
+
 /*
 The MIT License (MIT)
 

--- a/src/srnd/redis_cache.go
+++ b/src/srnd/redis_cache.go
@@ -1,3 +1,5 @@
+// +build !disable_redis
+
 package srnd
 
 import (

--- a/src/srnd/redis_disabled.go
+++ b/src/srnd/redis_disabled.go
@@ -1,0 +1,15 @@
+// +build disable_redis
+
+package srnd
+
+func NewRedisDatabase(host, port, password string) Database {
+	panic("Redis was disabled at compile time!");
+
+	return NewPostgresDatabase("", "", "", ""); //this shouldn't be reached
+}
+
+func NewRedisCache(prefix, webroot, name string, threads int, attachments bool, db Database, host, port, password string) CacheInterface {
+	panic("Redis was disabled at compile time!");
+	
+	return NewFileCache(prefix, webroot, name, threads, attachments, db, nil) //this shouldn't be reached
+}


### PR DESCRIPTION
Since people have been complaining about this, you can now pass `-tags disable_redis` to go when building and redis support will be disabled.